### PR TITLE
Discarding the master and slave language

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -14,7 +14,7 @@ def install_salt():
         else:
                 print(green("install salt-minion success"))
 def config_salt():
-#        result = run("sed -i 's/^#master:.*/master: 10.1.0.12/' %s" % path_config)
+#        result = run("sed -i 's/^#main:.*/main: 10.1.0.12/' %s" % path_config)
 #        if result.failed:
 #                abort(red("modifiy minion failed!!"))
 #        else:


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.